### PR TITLE
closure_templates_plugin: specify cfg = exec

### DIFF
--- a/closure/templates/closure_templates_plugin.bzl
+++ b/closure/templates/closure_templates_plugin.bzl
@@ -36,6 +36,7 @@ closure_templates_plugin = rule(
             doc = "java_library rules providing the specified class name",
             providers = [JavaInfo],
             mandatory = True,
+            cfg = "exec",
         ),
     },
     provides = [SoyPluginInfo],


### PR DESCRIPTION
The plugin runs on the host, and not specifying this causes cross-compilation to fail.