### PR TITLE
Fix: Transitive Protos

### DIFF
--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -46,7 +46,8 @@ def create_closure_js_library(
         exports = [],
         suppress = [],
         lenient = False,
-        convention = "CLOSURE"):
+        convention = "CLOSURE",
+        internal_descriptors = depset()):
     """ Returns closure_js_library metadata with provided attributes.
 
     Note that the returned struct is not a proper provider since existing contract
@@ -67,6 +68,9 @@ def create_closure_js_library(
         but also propagate up to closure_js_binary.
       lenient: makes the library lenient which suppresses handful of checkings in
         one shot.
+      convention: Coding convention to apply.
+      internal_descriptors: Proto descriptors defined within this target. Internal
+        use only, please.
 
     Returns:
       A closure_js_library metadata struct with exports and closure_js_library attribute
@@ -84,6 +88,7 @@ def create_closure_js_library(
         lenient = lenient,
         convention = convention,
         testonly = testonly,
+        internal_descriptors = internal_descriptors,
     )
 
 def _closure_js_library_impl(

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -16,12 +16,17 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
-load("//closure:defs.bzl", "closure_java_template_library", "closure_js_library", "closure_js_proto_library", "closure_js_template_library", "closure_js_test", "closure_templates_plugin")
+load("//closure:defs.bzl", "closure_java_template_library", "closure_js_library", "closure_proto_library", "closure_js_template_library", "closure_js_test", "closure_templates_plugin")
 load("//closure/private:file_test.bzl", "file_test")
 
-closure_js_proto_library(
+proto_library(
     name = "person_proto",
     srcs = ["person.proto"],
+)
+
+closure_proto_library(
+    name = "person_closure_proto",
+    deps = [":person_proto"],
 )
 
 closure_js_template_library(
@@ -100,7 +105,7 @@ closure_js_template_library(
     srcs = ["greeter_proto.soy"],
     deps = [
         ":greeter_soy",
-        ":person_proto",
+        ":person_closure_proto",
     ],
 )
 
@@ -118,7 +123,7 @@ closure_js_library(
     srcs = ["greeter_proto.js"],
     deps = [
         ":greeter_proto_soy",
-        ":person_proto",
+        ":person_closure_proto",
         "//closure/library/soy",
     ],
 )


### PR DESCRIPTION
This fixes an issue where protos declared transitively do not make themselves available for downstream dependencies (particularly, templates).

Original fix was from @pcj, but this amends it for Bazel post-`1.0.0`.