### PR TITLE
Fix: BZL Library Targets

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,1 +1,36 @@
-# Empty Bazel build file
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "//closure:defs.bzl",
+        "//closure:filegroup_external.bzl",
+        "//closure:repositories.bzl",
+    ],
+    deps = [
+        "//closure/compiler:compiler-bzl",
+        "//closure/protobuf:protobuf-bzl",
+        "//closure/stylesheets:stylesheets-bzl",
+        "//closure/templates:templates-bzl",
+        "//closure/webfiles:webfiles-bzl",
+    ]
+)

--- a/closure/BUILD
+++ b/closure/BUILD
@@ -14,7 +14,16 @@
 
 licenses(["notice"])  # Apache 2.0
 
+package(default_visibility = ["//visibility:public"])
+
 load("//closure/private:lines_sorted_test.bzl", "lines_sorted_test")
+
+
+exports_files([
+    "defs.bzl",
+    "repositories.bzl",
+    "filegroup_external.bzl",
+])
 
 lines_sorted_test(
     name = "repositories_defs_sorted_test",

--- a/closure/defs.bzl
+++ b/closure/defs.bzl
@@ -29,8 +29,8 @@ load("//closure/testing:closure_js_test.bzl", _closure_js_test = "closure_js_tes
 load("//closure/testing:phantomjs_test.bzl", _phantomjs_test = "phantomjs_test")
 load("//closure:filegroup_external.bzl", _filegroup_external = "filegroup_external")
 load("//closure:repositories.bzl", _closure_repositories = "closure_repositories")
-load("//closure:webfiles/web_library.bzl", _web_library = "web_library")
-load("//closure:webfiles/web_library_external.bzl", _web_library_external = "web_library_external")
+load("//closure/webfiles:web_library.bzl", _web_library = "web_library")
+load("//closure/webfiles:web_library_external.bzl", _web_library_external = "web_library_external")
 
 closure_js_aspect = _closure_js_aspect
 closure_js_binary = _closure_js_binary

--- a/closure/protobuf/BUILD
+++ b/closure/protobuf/BUILD
@@ -17,6 +17,16 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+
+bzl_library(
+    name = "protobuf-bzl",
+    srcs = [
+        "closure_js_proto_library.bzl",
+        "closure_proto_library.bzl",
+    ],
+)
 
 closure_js_library(
     name = "jspb",

--- a/closure/stylesheets/BUILD
+++ b/closure/stylesheets/BUILD
@@ -15,3 +15,14 @@
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+
+bzl_library(
+    name = "stylesheets-bzl",
+    srcs = [
+        "closure_css_binary.bzl",
+        "closure_css_library.bzl",
+    ],
+)

--- a/closure/templates/BUILD
+++ b/closure/templates/BUILD
@@ -18,6 +18,18 @@ licenses(["notice"])  # Apache 2.0
 
 load("@rules_java//java:defs.bzl", "java_library")
 load("//closure:defs.bzl", "closure_js_library", "closure_js_proto_library")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+
+bzl_library(
+    name = "templates-bzl",
+    srcs = [
+        "closure_java_template_library.bzl",
+        "closure_js_template_library.bzl",
+        "closure_py_template_library.bzl",
+        "closure_templates_plugin.bzl",
+    ],
+)
 
 java_library(
     name = "templates",

--- a/closure/webfiles/BUILD
+++ b/closure/webfiles/BUILD
@@ -16,22 +16,13 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-load("@rules_java//java:defs.bzl", "java_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 
 bzl_library(
-    name = "compiler-bzl",
+    name = "webfiles-bzl",
     srcs = [
-        "closure_base_js_library.bzl",
-        "closure_js_aspect.bzl",
-        "closure_js_binary.bzl",
-        "closure_js_deps.bzl",
-        "closure_js_library.bzl",
+        "web_library_external.bzl",
+        "web_library.bzl",
     ],
-)
-
-java_library(
-    name = "compiler",
-    exports = ["@com_google_javascript_closure_compiler"],
 )


### PR DESCRIPTION
This changeset adds `bzl_library` targets, so that downstream packages may reference them (for instance, when building Skydoc targets that make use of `rules_closure`).

So far:
- [x] Add `bzl_library` targets in each major sub-package
- [x] Change imports where needed because of new `BUILD` files